### PR TITLE
Jdojpa-37: Clean imports when type not used

### DIFF
--- a/src/main/java/com/ecpnv/openrewrite/java/JoinStringArrayAnnotationAttribute.java
+++ b/src/main/java/com/ecpnv/openrewrite/java/JoinStringArrayAnnotationAttribute.java
@@ -24,6 +24,26 @@ import org.openrewrite.java.tree.TypeUtils;
 import lombok.EqualsAndHashCode;
 import lombok.Value;
 
+/**
+ * A recipe designed for modifying annotations in Java source code by converting
+ * attributes that are string arrays into a single delimited string value within the
+ * annotation. This recipe targets a specific annotation type and attribute name
+ * and uses a user-defined delimiter for concatenation.
+ * <p>
+ * This class provides mechanisms for transforming Java annotations at the source
+ * code level where the attribute's values (if specified as an array of strings)
+ * are joined into a single concatenated string.
+ * <p>
+ * Features include:
+ * - Targeting a specific annotation type using its fully qualified name.
+ * - Specifying the attribute name to process.
+ * - Customizable delimiters for joining the string array elements.
+ * <p>
+ * The recipe utilizes internal visitors to inspect and modify the Abstract Syntax
+ * Tree (AST) of the Java source.
+ *
+ * @author Patrick Deenen @ Open Circle Solutions
+ */
 @Value
 @EqualsAndHashCode(callSuper = false)
 public class JoinStringArrayAnnotationAttribute extends Recipe {

--- a/src/main/java/com/ecpnv/openrewrite/java/MaybeRemoveImport.java
+++ b/src/main/java/com/ecpnv/openrewrite/java/MaybeRemoveImport.java
@@ -1,0 +1,46 @@
+package com.ecpnv.openrewrite.java;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import org.jspecify.annotations.NonNull;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Option;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.java.RemoveImport;
+
+import lombok.EqualsAndHashCode;
+import lombok.Value;
+
+@Value
+@EqualsAndHashCode(callSuper = false)
+public class MaybeRemoveImport extends Recipe {
+
+    @Option(displayName = "Type",
+            description = "The fully qualified name of the type.",
+            example = "org.junit.Test")
+    @NonNull
+    String type;
+
+    @Override
+    public String getDisplayName() {
+        return "Remove import when type is no longer used";
+    }
+
+    @Override
+    public String getDescription() {
+        return "When a type is no longer used in the class, remove from import.";
+    }
+
+    @JsonCreator
+    public MaybeRemoveImport(
+            @NonNull @JsonProperty("type") String type) {
+        this.type = type;
+    }
+
+    @Override
+    public TreeVisitor<?, ExecutionContext> getVisitor() {
+        return new RemoveImport<ExecutionContext>(type);
+    }
+}

--- a/src/main/java/com/ecpnv/openrewrite/jdo2jpa/Constants.java
+++ b/src/main/java/com/ecpnv/openrewrite/jdo2jpa/Constants.java
@@ -12,6 +12,8 @@ public final class Constants {
         public final static String COLUMN_ANNOTATION_FULL = BASE_PACKAGE + COLUMN_ANNOTATION_NAME;
         public final static String DISCRIMINATOR_ANNOTATION_NAME = "Discriminator";
         public final static String DISCRIMINATOR_ANNOTATION_FULL = BASE_PACKAGE + DISCRIMINATOR_ANNOTATION_NAME;
+        public final static String DISCRIMINATOR_STRATEGY_ANNOTATION_NAME = "DiscriminatorStrategy";
+        public final static String DISCRIMINATOR_STRATEGY_ANNOTATION_FULL = BASE_PACKAGE + DISCRIMINATOR_STRATEGY_ANNOTATION_NAME;
         public final static String ELEMENT_ANNOTATION_NAME = "Element";
         public final static String ELEMENT_ANNOTATION_FULL = BASE_PACKAGE + ELEMENT_ANNOTATION_NAME;
         public final static String INHERITANCE_ANNOTATION_NAME = "Inheritance";

--- a/src/main/java/com/ecpnv/openrewrite/jdo2jpa/ReplacePersistenceCapableWithTableAnnotation.java
+++ b/src/main/java/com/ecpnv/openrewrite/jdo2jpa/ReplacePersistenceCapableWithTableAnnotation.java
@@ -81,6 +81,8 @@ public class ReplacePersistenceCapableWithTableAnnotation extends Recipe {
                                     .orElse("");
                     // Add @Entity
                     maybeAddImport(TARGET_TYPE);
+                    maybeRemoveImport(Constants.Jdo.PERSISTENCE_CAPABLE_ANNOTATION_FULL);
+
                     return JavaTemplate.builder(template)
                             .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, Constants.Jpa.CLASS_PATH))
                             .imports(TARGET_TYPE)

--- a/src/main/java/com/ecpnv/openrewrite/jdo2jpa/ReplacePersistentWithManyToOneAnnotation.java
+++ b/src/main/java/com/ecpnv/openrewrite/jdo2jpa/ReplacePersistentWithManyToOneAnnotation.java
@@ -142,6 +142,7 @@ public class ReplacePersistentWithManyToOneAnnotation extends Recipe {
                     maybeAddImport(TARGET_TYPE);
                     maybeAddImport(Constants.Jpa.CASCADE_TYPE_FULL);
                     maybeAddImport(Constants.Jpa.FETCH_TYPE_FULL);
+                    maybeRemoveImport(Constants.Jdo.PERSISTENT_ANNOTATION_FULL);
 
                     return JavaTemplate.builder(template.toString())
                             .javaParser(JavaParser.fromJavaVersion().classpathFromResources(ctx, Constants.Jpa.CLASS_PATH))

--- a/src/main/java/com/ecpnv/openrewrite/jdo2jpa/ReplacePersistentWithOneToManyAnnotation.java
+++ b/src/main/java/com/ecpnv/openrewrite/jdo2jpa/ReplacePersistentWithOneToManyAnnotation.java
@@ -158,6 +158,7 @@ public class ReplacePersistentWithOneToManyAnnotation extends Recipe {
                     maybeAddImport(Constants.Jpa.CASCADE_TYPE_FULL);
                     maybeAddImport(Constants.Jpa.FETCH_TYPE_FULL);
                     maybeAddImport(Constants.Jpa.JOIN_TABLE_ANNOTATION_FULL);
+                    maybeRemoveImport(Constants.Jdo.PERSISTENT_ANNOTATION_FULL);
                     maybeRemoveImport(Constants.Jdo.JOIN_ANNOTATION_FULL);
                     maybeRemoveImport(Constants.Jdo.ELEMENT_ANNOTATION_FULL);
 

--- a/src/main/resources/META-INF/rewrite/datanucleus-jdo-to-jpa-eclipselink.yml
+++ b/src/main/resources/META-INF/rewrite/datanucleus-jdo-to-jpa-eclipselink.yml
@@ -57,6 +57,8 @@ recipeList:
   - com.ecpnv.openrewrite.jdo2jpa.ReplacePersistenceCapableWithTableAnnotation
   - org.openrewrite.java.RemoveAnnotation:
       annotationPattern: '@javax.jdo.annotations.PersistenceCapable'
+  - com.ecpnv.openrewrite.java.MaybeRemoveImport:
+      type: javax.jdo.annotations.IdentityType
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: com.ecpnv.openrewrite.jdo2jpa.v2x.Persistent
@@ -301,6 +303,8 @@ recipeList:
   - org.openrewrite.java.RemoveAnnotationAttribute:
       annotationType: javax.persistence.DiscriminatorValue
       attributeName: indexed
+  - com.ecpnv.openrewrite.java.MaybeRemoveImport:
+      type: javax.jdo.annotations.DiscriminatorStrategy
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: com.ecpnv.openrewrite.jdo2jpa.v2x.Inheritance
@@ -368,4 +372,7 @@ recipeList:
   - org.openrewrite.java.RemoveAnnotationAttribute:
       annotationType: javax.persistence.Inheritance
       attributeName: customStrategy
+  - com.ecpnv.openrewrite.java.MaybeRemoveImport:
+      type: javax.jdo.annotations.InheritanceStrategy
+
 

--- a/src/test/java/com/ecpnv/openrewrite/java/MaybeRemoveImportTest.java
+++ b/src/test/java/com/ecpnv/openrewrite/java/MaybeRemoveImportTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ecpnv.openrewrite.java;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RecipeSpec;
+
+import static org.openrewrite.java.Assertions.java;
+
+import com.ecpnv.openrewrite.jdo2jpa.BaseRewriteTest;
+import com.ecpnv.openrewrite.jdo2jpa.Constants;
+
+
+/**
+ * @author Patrick Deenen @ Open Circle Solutions
+ */
+class MaybeRemoveImportTest extends BaseRewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.parser(PARSER).recipe(new MaybeRemoveImport(Constants.Jdo.DISCRIMINATOR_STRATEGY_ANNOTATION_FULL));
+    }
+
+    @DocumentExample
+    @Test
+    void moveIndexConstraintAnnotation() {
+        rewriteRun(//language=java
+                java(
+                        """
+                                import javax.jdo.annotations.DiscriminatorStrategy;
+                                
+                                public class SomeEntity {}
+                                """,
+                        """
+                                public class SomeEntity {}
+                                """
+                )
+        );
+    }
+}

--- a/src/test/java/com/ecpnv/openrewrite/jdo2jpa/CopyDiscriminatorFromParentTest.java
+++ b/src/test/java/com/ecpnv/openrewrite/jdo2jpa/CopyDiscriminatorFromParentTest.java
@@ -99,6 +99,7 @@ class CopyDiscriminatorFromParentTest extends BaseRewriteTest {
                         """
                                 import java.util.List;
                                 import javax.jdo.annotations.Discriminator;
+                                import javax.jdo.annotations.DiscriminatorStrategy;
                                 import javax.jdo.annotations.Persistent;
                                 
                                 @Discriminator(strategy = DiscriminatorStrategy.CLASS_NAME)
@@ -114,6 +115,7 @@ class CopyDiscriminatorFromParentTest extends BaseRewriteTest {
                         """
                                 import java.util.List;
                                 import javax.jdo.annotations.Discriminator;
+                                import javax.jdo.annotations.DiscriminatorStrategy;
                                 import javax.jdo.annotations.Persistent;
                                 
                                 @Discriminator(value = "Person", strategy = DiscriminatorStrategy.CLASS_NAME)

--- a/src/test/java/com/ecpnv/openrewrite/jdo2jpa/DiscriminatorTest.java
+++ b/src/test/java/com/ecpnv/openrewrite/jdo2jpa/DiscriminatorTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ecpnv.openrewrite.jdo2jpa;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RecipeSpec;
+
+import static org.openrewrite.java.Assertions.java;
+
+/**
+ * @author Patrick Deenen @ Open Circle Solutions
+ */
+class DiscriminatorTest extends BaseRewriteTest {
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.parser(PARSER).recipeFromResources("com.ecpnv.openrewrite.jdo2jpa.v2x.Discriminator");
+    }
+
+    /**
+     * Tests the transformation of non-inherited annotations applied to classes
+     * from JDO (@Discriminator) to JPA (@DiscriminatorValue and @DiscriminatorColumn)
+     * with the strategy set to CLASS_NAME. This allows ensuring that class-level
+     * annotations in the JDO model are correctly converted to reflect the JPA
+     * discriminator strategy and values for the inheritance hierarchy.
+     * <p>
+     * The method validates that:
+     * 1. The original @Discriminator annotation in JDO is replaced by the
+     * corresponding @DiscriminatorValue and @DiscriminatorColumn annotations in JPA.
+     * 2. Each class in the hierarchy correctly receives the expected configuration
+     * for discriminator values and column definitions.
+     */
+    @DocumentExample
+    @Test
+    void copyNonInheritedAnnotationsUsingClassnameWithStrategy() {
+        rewriteRun(
+                //language=java
+                java(
+                        """
+                                import java.util.List;
+                                import javax.jdo.annotations.Discriminator;
+                                import javax.jdo.annotations.DiscriminatorStrategy;
+                                
+                                @Discriminator(strategy = DiscriminatorStrategy.CLASS_NAME)
+                                public class Person {
+                                        private int id;
+                                        private String name;
+                                }
+                                public class Manager extends Person {
+                                        private List<Person> managedPersons;
+                                }
+                                """,
+                        """
+                                import java.util.List;
+                                import javax.persistence.DiscriminatorColumn;
+                                import javax.persistence.DiscriminatorValue;
+                                
+                                @DiscriminatorValue(value = "Person")
+                                @DiscriminatorColumn(name = "discriminator", length = 255)
+                                public class Person {
+                                        private int id;
+                                        private String name;
+                                }
+                                
+                                @DiscriminatorValue(value = "Manager")
+                                @DiscriminatorColumn(name = "discriminator", length = 255)
+                                public class Manager extends Person {
+                                        private List<Person> managedPersons;
+                                }
+                                """
+                )
+        );
+    }
+}

--- a/src/test/java/com/ecpnv/openrewrite/jdo2jpa/IndexesTest.java
+++ b/src/test/java/com/ecpnv/openrewrite/jdo2jpa/IndexesTest.java
@@ -34,6 +34,37 @@ class IndexesTest extends BaseRewriteTest {
         spec.parser(PARSER).recipeFromResources("com.ecpnv.openrewrite.jdo2jpa.v2x.Index");
     }
 
+    /**
+     * The `moveIndexConstraintAnnotation` method is a test case validating the transformation and migration of
+     * `javax.persistence.Index` annotations into an `indexes` attribute of the `javax.persistence.Table` annotation
+     * within an annotated class declaration.
+     * <p>
+     * This method utilizes the `MoveAnnotationsToAttribute` recipe to achieve the following:
+     * <p>
+     * - Locates the `@Index` annotation applied to a class.
+     * - Integrates the `@Index` definitions into the `indexes` attribute of the `@Table` annotation,
+     * ensuring adherence to proper syntax and imports.
+     * - Retains other existing attributes of the `@Table` annotation and consolidates the changes.
+     * - Removes the standalone `@Index` annotation from the class after its values are successfully migrated.
+     * <p>
+     * Key Features:
+     * - Verifies the correct transformation of annotations by asserting the resulting structure of the class.
+     * - Ensures that the `@Table` annotation is accurately augmented with the `indexes` attribute, incorporating
+     * all existing `@Index` instances.
+     * - Confirms clean and syntactically valid code by removing unnecessary annotations and maintaining appropriate imports.
+     * <p>
+     * Preconditions:
+     * - The target class contains one or more `@Index` annotations and an existing `@Table` annotation.
+     * <p>
+     * Postconditions:
+     * - The `@Index` annotations are embedded within the `indexes` attribute of the `@Table` annotation.
+     * - The original `@Index` annotations are removed from the class.
+     * <p>
+     * Dependencies:
+     * - The `MoveAnnotationsToAttribute` recipe is used to perform the migration.
+     * - Constants for fully qualified annotation names (`Constants.Jpa.INDEX_ANNOTATION_FULL` and `Constants.Jpa.TABLE_ANNOTATION_FULL`)
+     * and the `indexes` attribute name (`Constants.Jpa.TABLE_ARGUMENT_INDEXES`) are leveraged to guide the transformation.
+     */
     @DocumentExample
     @Test
     void moveIndexConstraintAnnotation() {
@@ -69,6 +100,38 @@ class IndexesTest extends BaseRewriteTest {
         );
     }
 
+    /**
+     * The `moveIndexConstraintAnnotationWithNoPreexistingTableAnnotation` method is a test case designed
+     * to validate the behavior of moving `@Index` annotations into the `indexes` attribute of the
+     * `@javax.persistence.Table` annotation when there is no preexisting `@Table` annotation in the
+     * class being processed.
+     *
+     * This method performs the following:
+     *
+     * - Applies the `MoveAnnotationsToAttribute` recipe, which facilitates the migration of
+     *   `@Index` annotations into the `indexes` attribute of the `@Table` annotation in classes.
+     * - Ensures that a `@Table` annotation is added to the class if it does not already exist.
+     * - Validates the transformation process by comparing the input and expected output class declarations.
+     * - Verifies that the `indexes` attribute of the newly added `@Table` annotation is populated with
+     *   the corresponding `@Index` annotations, and that the standalone `@Index` annotations are removed.
+     * - Ensures the proper imports are added for the `javax.persistence.Table` and `javax.persistence.Index`
+     *   annotations.
+     *
+     * Preconditions:
+     * - The target class contains one or more `@Index` annotations and does not have an existing
+     *   `@Table` annotation.
+     *
+     * Postconditions:
+     * - A new `@Table` annotation is added to the class.
+     * - The `@Index` annotations are embedded within the `indexes` attribute of the `@Table` annotation.
+     * - The standalone `@Index` annotations are removed.
+     *
+     * Dependencies:
+     * - The `MoveAnnotationsToAttribute` recipe is used for the transformation.
+     * - Constants such as `Constants.Jpa.INDEX_ANNOTATION_FULL`, `Constants.Jpa.TABLE_ANNOTATION_FULL`,
+     *   and `Constants.Jpa.TABLE_ARGUMENT_INDEXES` are utilized to define the fully qualified names
+     *   and attribute name during the migration process.
+     */
     @DocumentExample
     @Test
     void moveIndexConstraintAnnotationWithNoPreexistingTableAnnotation() {
@@ -102,6 +165,34 @@ class IndexesTest extends BaseRewriteTest {
         );
     }
 
+    /**
+     * The `moveMultipleIndexConstraintAnnotation` method is a test case aimed at validating the transformation
+     * of multiple `@Index` annotations into the `indexes` attribute of the `@javax.persistence.Table` annotation
+     * within a class declaration.
+     *
+     * This method performs the following tasks:
+     *
+     * - Utilizes the `MoveAnnotationsToAttribute` recipe to migrate multiple `@Index` annotations into the
+     *   `indexes` attribute of the existing `@Table` annotation.
+     * - Ensures that all `@Index` annotations are properly grouped under a singular `indexes` attribute of the
+     *   `@Table` annotation while preserving correct syntax and semantics.
+     * - Verifies that the standalone `@Index` annotations are removed from the class after their migration.
+     * - Asserts the correctness of the transformation by comparing the generated code structure with
+     *   expected outcomes.
+     *
+     * Preconditions:
+     * - The target class contains two or more `@Index` annotations and an existing `@Table` annotation.
+     *
+     * Postconditions:
+     * - The `@Index` annotations are embedded within the `indexes` attribute of the `@Table` annotation.
+     * - All standalone `@Index` annotations are removed.
+     * - The integrity of the class structure, including imports and other annotations, is maintained.
+     *
+     * Dependencies:
+     * - The `MoveAnnotationsToAttribute` recipe is used for executing the migration process.
+     * - Fully qualified constants, including `Constants.Jpa.INDEX_ANNOTATION_FULL`, `Constants.Jpa.TABLE_ANNOTATION_FULL`,
+     *   and `Constants.Jpa.TABLE_ARGUMENT_INDEXES`, are referenced to guide the transformation accurately.
+     */
     @DocumentExample
     @Test
     void moveMultipleIndexConstraintAnnotation() {
@@ -139,6 +230,33 @@ class IndexesTest extends BaseRewriteTest {
         );
     }
 
+    /**
+     * Validates the transformation of a `@Index` annotation into the `indexes` attribute
+     * of a `@Table` annotation in a class declaration.
+     *
+     * This method ensures migration of the `@Index` annotation to be part of the `indexes`
+     * attribute inside the `@Table` annotation while maintaining the integrity of other
+     * existing annotations and imports. The standalone `@Index` annotation is removed after
+     * its transformation.
+     *
+     * Key Features:
+     * - Converts `@Index` to an inline definition within the `indexes` attribute of the `@Table` annotation.
+     * - Ensures proper syntax and semantically valid annotation structure.
+     * - Removes redundant `@Index` annotations after they are migrated.
+     * - Validates the accuracy of the updated structure by comparing it to the expected output.
+     *
+     * Preconditions:
+     * - A `@Index` annotation exists within the class body, alongside a `@Table` annotation where it will be incorporated.
+     *
+     * Postconditions:
+     * - The `@Index` definition is moved into the `indexes` attribute of the `@Table` annotation.
+     * - The `@Index` annotation is removed from its previous standalone position.
+     * - Proper imports for the modified annotations are retained or introduced.
+     *
+     * Dependencies:
+     * - Relies on the `MoveAnnotationsToAttribute` recipe for modifying and relocating annotations.
+     * - Utilizes constants for annotation names and attributes to guide the transformation process.
+     */
     @DocumentExample
     @Test
     void moveIndexAnnotation() {
@@ -173,6 +291,37 @@ class IndexesTest extends BaseRewriteTest {
         );
     }
 
+    /**
+     * The `moveIndexAnnotationFromIndexes` method is a test case designed to validate the migration
+     * of `@javax.jdo.annotations.Index` annotations in a JDO entity class to the `indexes` attribute
+     * of the `@javax.persistence.Table` annotation in a JPA entity class.
+     *
+     * This method ensures the proper transformation of the entity class from JDO to JPA by:
+     * - Converting standalone `@Index` annotations into inline definitions under the `indexes` attribute
+     *   of the `@Table` annotation.
+     * - Ensuring that all the indices specified for the JDO entity are preserved and correctly formatted
+     *   as part of the JPA entity class.
+     * - Retaining existing `@PersistenceCapable` schema configurations and translating it to
+     *   the JPA equivalent using `@Table`'s `schema` attribute.
+     * - Removing the original standalone `@Index` annotations after migration to prevent redundancy.
+     * - Ensuring that imports are updated to reflect the transition from JDO to JPA annotations.
+     *
+     * Preconditions:
+     * - The input class must be annotated with `@PersistenceCapable`.
+     * - One or more `@Index` annotations exist in the JDO entity class.
+     *
+     * Postconditions:
+     * - `@PersistenceCapable` is replaced with equivalent `@Entity` and `@Table` annotations.
+     * - The `indexes` attribute in the `@Table` annotation contains all the converted `@Index` annotations.
+     * - Redundant `@Index` annotations from JDO are removed.
+     * - Proper imports for JPA annotations are added and imports for JDO annotations are excluded.
+     *
+     * Dependencies:
+     * - Relies on the `MoveAnnotationsToAttribute` recipe to handle the transformation of index
+     *   annotations into the `indexes` attribute of the `@javax.persistence.Table` annotation.
+     * - Assumes the presence of utilities or constants for managing fully qualified names of
+     *   JDO and JPA annotations and their attributes.
+     */
     @DocumentExample
     @Test
     void moveIndexAnnotationFromIndexes() {

--- a/src/test/java/com/ecpnv/openrewrite/jdo2jpa/InheritanceTest.java
+++ b/src/test/java/com/ecpnv/openrewrite/jdo2jpa/InheritanceTest.java
@@ -140,7 +140,6 @@ class InheritanceTest extends BaseRewriteTest {
                                 """,
                         """
                                 import java.util.List;
-                                import javax.jdo.annotations.InheritanceStrategy;
                                 import javax.persistence.Inheritance;
                                 
                                 @Inheritance(strategy = javax.persistence.InheritanceType.JOINED)
@@ -256,7 +255,6 @@ class InheritanceTest extends BaseRewriteTest {
                                 """,
                         """
                                 import java.util.List;
-                                import javax.jdo.annotations.InheritanceStrategy;
                                 import javax.persistence.Inheritance;
                                 
                                 @Inheritance(strategy = javax.persistence.InheritanceType.SINGLE_TABLE)
@@ -312,7 +310,6 @@ class InheritanceTest extends BaseRewriteTest {
                                 """,
                         """
                                 import java.util.List;
-                                import javax.jdo.annotations.InheritanceStrategy;
                                 import javax.persistence.Inheritance;
                                 
                                 @Inheritance(strategy = javax.persistence.InheritanceType.TABLE_PER_CLASS)

--- a/src/test/java/com/ecpnv/openrewrite/jdo2jpa/ReplacePersistenceCapableWithTableAnnotationTest.java
+++ b/src/test/java/com/ecpnv/openrewrite/jdo2jpa/ReplacePersistenceCapableWithTableAnnotationTest.java
@@ -68,7 +68,6 @@ class ReplacePersistenceCapableWithTableAnnotationTest extends BaseRewriteTest {
                 """,
         """
                 import java.util.List;
-                import javax.jdo.annotations.PersistenceCapable;
                 import javax.persistence.Table;
                 
                 @Table(schema = "schemaName")
@@ -80,4 +79,34 @@ class ReplacePersistenceCapableWithTableAnnotationTest extends BaseRewriteTest {
             )
         );
     }
+
+    @DocumentExample
+    @Test
+    void addEntityReplaceWithTableAnnotation() {
+        rewriteRun(spec -> spec.recipeFromResources("com.ecpnv.openrewrite.jdo2jpa.v2x.PersistenceCapable"),
+                //language=java
+                java(
+                        """
+                                import java.util.List;
+                                import javax.jdo.annotations.PersistenceCapable;
+                                import javax.jdo.annotations.IdentityType;
+                                
+                                @PersistenceCapable(schema = "schemaName", identityType = IdentityType.APPLICATION)
+                                public class SomeEntity {
+                                }
+                                """,
+                        """
+                                import java.util.List;
+                                import javax.persistence.Entity;
+                                import javax.persistence.Table;
+                                
+                                @Entity
+                                @Table(schema = "schemaName")
+                                public class SomeEntity {
+                                }
+                                """
+                )
+        );
+    }
+
 }

--- a/src/test/java/com/ecpnv/openrewrite/jdo2jpa/ReplacePersistentWithManyToOneAnnotationTest.java
+++ b/src/test/java/com/ecpnv/openrewrite/jdo2jpa/ReplacePersistentWithManyToOneAnnotationTest.java
@@ -71,7 +71,6 @@ class ReplacePersistentWithManyToOneAnnotationTest extends BaseRewriteTest {
                                 import javax.persistence.Entity;
                                 import javax.persistence.FetchType;
                                 import javax.persistence.ManyToOne;
-                                import javax.jdo.annotations.Persistent;
                                 
                                 @Entity
                                 public class Person {}
@@ -123,7 +122,6 @@ class ReplacePersistentWithManyToOneAnnotationTest extends BaseRewriteTest {
                                 import javax.persistence.Entity;
                                 import javax.persistence.FetchType;
                                 import javax.persistence.ManyToOne;
-                                import javax.jdo.annotations.Persistent;
                                 
                                 @Entity
                                 public class Person {}
@@ -176,7 +174,6 @@ class ReplacePersistentWithManyToOneAnnotationTest extends BaseRewriteTest {
                                 import javax.persistence.Entity;
                                 import javax.persistence.FetchType;
                                 import javax.persistence.ManyToOne;
-                                import javax.jdo.annotations.Persistent;
                                 
                                 @Entity
                                 public class Person {}

--- a/src/test/java/com/ecpnv/openrewrite/jdo2jpa/ReplacePersistentWithOneToManyAnnotationTest.java
+++ b/src/test/java/com/ecpnv/openrewrite/jdo2jpa/ReplacePersistentWithOneToManyAnnotationTest.java
@@ -69,7 +69,6 @@ class ReplacePersistentWithOneToManyAnnotationTest extends BaseRewriteTest {
                 """,
         """
                 import java.util.List;
-                import javax.jdo.annotations.Persistent;
                 import javax.persistence.FetchType;
                 import javax.persistence.OneToMany;
                 
@@ -110,7 +109,6 @@ class ReplacePersistentWithOneToManyAnnotationTest extends BaseRewriteTest {
                 """,
         """
                 import java.util.List;
-                import javax.jdo.annotations.Persistent;
                 import javax.persistence.FetchType;
                 import javax.persistence.OneToMany;
                 
@@ -151,7 +149,6 @@ class ReplacePersistentWithOneToManyAnnotationTest extends BaseRewriteTest {
                                 """,
                         """
                                 import java.util.List;
-                                import javax.jdo.annotations.Persistent;
                                 import javax.persistence.CascadeType;
                                 import javax.persistence.FetchType;
                                 import javax.persistence.OneToMany;
@@ -190,7 +187,6 @@ class ReplacePersistentWithOneToManyAnnotationTest extends BaseRewriteTest {
                                 """,
                         """
                                 import java.util.List;
-                                import javax.jdo.annotations.Persistent;
                                 import javax.persistence.FetchType;
                                 import javax.persistence.OneToMany;
                                 
@@ -229,7 +225,6 @@ class ReplacePersistentWithOneToManyAnnotationTest extends BaseRewriteTest {
                                 """,
                         """
                                 import java.util.List;
-                                import javax.jdo.annotations.Persistent;
                                 import javax.persistence.CascadeType;
                                 import javax.persistence.FetchType;
                                 import javax.persistence.OneToMany;
@@ -268,7 +263,6 @@ class ReplacePersistentWithOneToManyAnnotationTest extends BaseRewriteTest {
                                 """,
                         """
                                 import java.util.List;
-                                import javax.jdo.annotations.Persistent;
                                 import javax.persistence.FetchType;
                                 import javax.persistence.JoinTable;
                                 import javax.persistence.OneToMany;


### PR DESCRIPTION
Naking sure that following imports are removed when migrated:
import javax.jdo.annotations.DiscriminatorStrategy;
import javax.jdo.annotations.IdentityType;
import javax.jdo.annotations.InheritanceStrategy;
import javax.jdo.annotations.PersistenceCapable;
import javax.jdo.annotations.Persistent;