### PR TITLE
JDOJPA-131: Always add @DiscriminatorColumn for @Inheritence

### DIFF
--- a/src/main/resources/META-INF/rewrite/datanucleus-jdo-to-jpa-eclipselink.yml
+++ b/src/main/resources/META-INF/rewrite/datanucleus-jdo-to-jpa-eclipselink.yml
@@ -361,12 +361,12 @@ recipeList:
   # Translate discriminator strategy of class name to discriminator values with the names of the classes
   # by copying @Discriminator from parent class to subclasses when omitted and use the subclass name
   - com.ecpnv.openrewrite.jdo2jpa.CopyDiscriminatorFromParent
-  # Add @DiscriminatorColumn for every @Discriminator
+  # Add @DiscriminatorColumn for every @Discriminator or @Inheritance
   # Set discriminator column name: discriminator
   # Set discriminator column length: 255
   # Note that from v5.0.2 DataNucleus will use a discriminator by default for inheritance strategy single table
   - com.ecpnv.openrewrite.java.AddAnnotationConditionally:
-      matchByRegularExpression: '@.*Discriminator(.|\s|\n)*'
+      matchByRegularExpression: '@.*(Discriminator|Inheritance)(.|\s|\n)*'
       annotationType: javax.persistence.DiscriminatorColumn
       annotationTemplate: '@DiscriminatorColumn( name = "discriminator", length = 255)'
       declarationType: CLASS
@@ -404,7 +404,7 @@ tags:
   - persistence
   - Inheritance
 recipeList:
-  # Copy @Inheritance to parent when parent is not an object
+  # Move @Inheritance to parent when parent is not an object
   - com.ecpnv.openrewrite.java.CopyAnnotationToSuper:
       move: true
       annotationTypes:


### PR DESCRIPTION
Always add @DiscriminatorColumn when @Inheritence is defined to support class name strategy with names longer then the default 31 chars