### PR TITLE
JDOJPA-312: Bug when checking modifier types of parent class

### DIFF
--- a/src/main/java/com/ecpnv/openrewrite/java/AddAnnotationConditionally.java
+++ b/src/main/java/com/ecpnv/openrewrite/java/AddAnnotationConditionally.java
@@ -274,7 +274,9 @@ public class AddAnnotationConditionally extends Recipe {
                     // do nothing
                 }
                 var cls = TypeUtils.asClass(pt);
-                if (flag == null || (cls != null && cls.hasFlags(flag))) {
+                if (flag == null
+                        || (pt instanceof JavaType.FullyQualified && ((JavaType.FullyQualified) pt).hasFlags(flag))
+                        || (cls != null && cls.hasFlags(flag))) {
                     return true;
                 }
                 return false;


### PR DESCRIPTION
JDOJPA-312: As the type of the class is not always provided by Rewrite a workaround is provided by first checking the metadata of rewrite class info before the class is checked