### PR TITLE
Fix review findings in ReplacePersistentWithManyToOneAnnotation

### DIFF
--- a/src/main/java/com/ecpnv/openrewrite/jdo2jpa/Constants.java
+++ b/src/main/java/com/ecpnv/openrewrite/jdo2jpa/Constants.java
@@ -39,6 +39,7 @@ public final class Constants {
         public static final String PERSISTENCE_CAPABLE_ANNOTATION_FULL = BASE_PACKAGE + PERSISTENCE_CAPABLE_ANNOTATION_NAME;
         public static final String PERSISTENT_ANNOTATION_NAME = "Persistent";
         public static final String PERSISTENT_ANNOTATION_FULL = BASE_PACKAGE + PERSISTENT_ANNOTATION_NAME;
+        public static final String PERSISTENT_ARGUMENT_DEPENDENT = "dependent";
         public static final String PERSISTENT_ARGUMENT_DEPENDENT_ELEMENT = "dependentElement";
         public static final String PERSISTENT_ARGUMENT_DEFAULT_FETCH_GROUP = "defaultFetchGroup";
         public static final String PERSISTENT_ARGUMENT_TABLE = "table";

--- a/src/main/java/com/ecpnv/openrewrite/jdo2jpa/ReplacePersistentWithManyToOneAnnotation.java
+++ b/src/main/java/com/ecpnv/openrewrite/jdo2jpa/ReplacePersistentWithManyToOneAnnotation.java
@@ -141,8 +141,9 @@ public class ReplacePersistentWithManyToOneAnnotation extends ScanningRecipe<Rep
                                                 .map(JavaType.FullyQualified::getFullyQualifiedName)
                                                 // Is it an entity with a mappedBy definition?
                                                 .ifPresent(name -> acc.varPersistentWithMappedBy
-                                                        // Then add fqn#varname,column-name-value to accumulator
-                                                        .put(name, assignment.getAssignment().toString()));
+                                                        // Register the mappedBy field name under the target type
+                                                        .computeIfAbsent(name, k -> new HashSet<>())
+                                                        .add(assignment.getAssignment().toString()));
                                     });
                         }
                         return mv;
@@ -192,7 +193,9 @@ public class ReplacePersistentWithManyToOneAnnotation extends ScanningRecipe<Rep
             if (RewriteUtils.isMethodOwnerOfVar(multiVariable)) {
                 return multiVariable;
             }
-            // Exit if an annotation with mappedBy exists
+            // Exit if an annotation with mappedBy exists. The inverse (non-owning) side of a
+            // bi-directional relationship is migrated to @OneToOne by
+            // ReplacePersistentWithOneToManyAnnotation, so it is intentionally skipped here.
             if (RewriteUtils.findArgumentAssignment(
                     FindAnnotations.find(multiVariable, SOURCE_ANNOTATION_TYPE),
                     Constants.Jpa.ONE_TO_MANY_ARGUMENT_MAPPED_BY).isPresent()) {
@@ -207,19 +210,13 @@ public class ReplacePersistentWithManyToOneAnnotation extends ScanningRecipe<Rep
                         .findFirst()
                         .map(J.VariableDeclarations.NamedVariable::getSimpleName)
                         .orElse(null);
-                if (Optional.ofNullable(RewriteUtils.findParentClass(getCursor()))
-                        .map(J.ClassDeclaration::getType)
-                        .map(JavaType.FullyQualified::getFullyQualifiedName)
-                        .map(fqn -> acc.varPersistentWithMappedBy.get(fqn))
-                        .map(mappedByName -> mappedByName.equals(fieldName))
-                        .orElse(false)) {
-                    // It is a bi-directional relationship using a @OneToOne relationship
+                if (isOwningSideOfBidirectionalOneToOne(fieldName)) {
+                    // It is the owning side of a bi-directional @OneToOne relationship
                     template.append(Constants.Jpa.ONE_TO_ONE_ANNOTATION_NAME).append("(");
                 } else {
                     // Using the ManyToOne
                     template.append(TARGET_TYPE_NAME).append("(");
                 }
-
 
                 List<J.Annotation> leadAnnos = new ArrayList<>(multiVariable.getLeadingAnnotations());
                 // Search for @Column
@@ -281,47 +278,44 @@ public class ReplacePersistentWithManyToOneAnnotation extends ScanningRecipe<Rep
 
                 // Find optional source annotation (@Persistent)
                 Optional<J.Annotation> sourceAnnotationIfAny = FindAnnotations.find(multiVariable, SOURCE_ANNOTATION_TYPE).stream().findFirst();
-                // Search for dependentElement
+                // For single-valued references JDO uses `dependent` (`dependentElement` applies to
+                // collection elements). Check `dependent` first and fall back to `dependentElement`.
                 boolean isDependent = sourceAnnotationIfAny
-                        .flatMap(annotation -> RewriteUtils.findArgumentAsBoolean(annotation, Constants.Jdo.PERSISTENT_ARGUMENT_DEPENDENT_ELEMENT))
+                        .flatMap(annotation -> RewriteUtils.findArgumentAsBoolean(annotation, Constants.Jdo.PERSISTENT_ARGUMENT_DEPENDENT)
+                                .or(() -> RewriteUtils.findArgumentAsBoolean(annotation, Constants.Jdo.PERSISTENT_ARGUMENT_DEPENDENT_ELEMENT)))
                         .orElse(false);
-                sourceAnnotationIfAny.ifPresent(annotation -> {
-                    // When @Persistence is found replace
-                    leadAnnos.remove(annotation);
+                // Remove the @Persistent annotation when present
+                sourceAnnotationIfAny.ifPresent(leadAnnos::remove);
 
-                    // dependentElement
-                    if (isDependent) {
-                        template
-                                .append(added.get() ? ", " : "")
-                                .append("cascade = {CascadeType.REMOVE")
-                                .append(StringUtils.isBlank(defaultCascade) ? "" : ", " + defaultCascade)
-                                .append("}");
-                        added.set(true);
-                    }
-
-                    // Search for defaultFetchGroup
+                // A dependent single reference maps to a REMOVE cascade
+                if (isDependent) {
                     template
                             .append(added.get() ? ", " : "")
-                            .append("fetch = FetchType.");
-                    RewriteUtils.findArgumentAsBoolean(annotation, Constants.Jdo.PERSISTENT_ARGUMENT_DEFAULT_FETCH_GROUP)
-                            .ifPresentOrElse(isDefault -> {
-                                if (Boolean.TRUE.equals(isDefault))
-                                    template.append("EAGER");
-                                else
-                                    template.append("LAZY");
-                            }, () -> template.append("LAZY")
-                            );
+                            .append("cascade = {CascadeType.REMOVE")
+                            .append(StringUtils.isBlank(defaultCascade) ? "" : ", " + defaultCascade)
+                            .append("}");
                     added.set(true);
-                });
-                if (sourceAnnotationIfAny.isEmpty() || !isDependent) {
-                    // Add the default cascade only
-                    if (!StringUtils.isBlank(defaultCascade)) {
-                        template
-                                .append(added.get() ? ", " : "")
-                                .append(" cascade = {")
-                                .append(defaultCascade)
-                                .append("}");
-                    }
+                }
+
+                // Always set the fetch type explicitly. JDO single references are lazy by default,
+                // whereas JPA @ManyToOne/@OneToOne default to EAGER; making the JDO default explicit
+                // avoids a silent lazy-to-eager change, also for fields without an @Persistent annotation.
+                template
+                        .append(added.get() ? ", " : "")
+                        .append("fetch = FetchType.");
+                sourceAnnotationIfAny
+                        .flatMap(annotation -> RewriteUtils.findArgumentAsBoolean(annotation, Constants.Jdo.PERSISTENT_ARGUMENT_DEFAULT_FETCH_GROUP))
+                        .ifPresentOrElse(isDefault -> template.append(Boolean.TRUE.equals(isDefault) ? "EAGER" : "LAZY"),
+                                () -> template.append("LAZY"));
+                added.set(true);
+
+                // Add the default cascade for non-dependent references
+                if (!isDependent && !StringUtils.isBlank(defaultCascade)) {
+                    template
+                            .append(added.get() ? ", " : "")
+                            .append("cascade = {")
+                            .append(defaultCascade)
+                            .append("}");
                 }
 
                 template.append(")");
@@ -357,11 +351,29 @@ public class ReplacePersistentWithManyToOneAnnotation extends ScanningRecipe<Rep
             }
             return multiVariable;
         }
+
+        /**
+         * Determines whether the field with the given name is the owning side of a bi-directional
+         * one-to-one relationship, i.e. the inverse side (in another entity) declares a
+         * {@code mappedBy} that points back to this field. The lookup uses the set of mappedBy names
+         * collected per target type so that multiple relationships to the same type are all matched.
+         */
+        private boolean isOwningSideOfBidirectionalOneToOne(String fieldName) {
+            return Optional.ofNullable(RewriteUtils.findParentClass(getCursor()))
+                    .map(J.ClassDeclaration::getType)
+                    .map(JavaType.FullyQualified::getFullyQualifiedName)
+                    .map(fqn -> acc.varPersistentWithMappedBy.get(fqn))
+                    .map(mappedByNames -> mappedByNames.contains(fieldName))
+                    .orElse(false);
+        }
     }
 
     @Data
     protected static class Accumulator {
         Set<String> entityClasses = new HashSet<>();
-        Map<String, String> varPersistentWithMappedBy = new java.util.HashMap<>();
+        // Maps a target entity type to the set of mappedBy field names that reference it from the
+        // inverse side. A set (not a single value) is required so that multiple bi-directional
+        // relationships to the same target type do not overwrite each other.
+        Map<String, Set<String>> varPersistentWithMappedBy = new java.util.HashMap<>();
     }
 }

--- a/src/test/java/com/ecpnv/openrewrite/jdo2jpa/JoinColumnTest.java
+++ b/src/test/java/com/ecpnv/openrewrite/jdo2jpa/JoinColumnTest.java
@@ -71,7 +71,7 @@ public class JoinColumnTest extends BaseRewriteTest {
                                 
                                     @Getter 
                                     @Setter
-                                    @ManyToOne(optional = false, cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REFRESH, CascadeType.DETACH})
+                                    @ManyToOne(optional = false, fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REFRESH, CascadeType.DETACH})
                                     @JoinColumn(nullable = false, name = "countryId")
                                     private Country country;
                                 }
@@ -118,6 +118,7 @@ public class JoinColumnTest extends BaseRewriteTest {
                                 
                                 import javax.persistence.CascadeType;
                                 import javax.persistence.Entity;
+                                import javax.persistence.FetchType;
                                 import javax.persistence.ManyToOne;
                                 
                                 import lombok.Getter;
@@ -138,7 +139,7 @@ public class JoinColumnTest extends BaseRewriteTest {
                                 
                                     @Getter
                                     @Setter
-                                    @ManyToOne(cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REFRESH, CascadeType.DETACH})
+                                    @ManyToOne(fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REFRESH, CascadeType.DETACH})
                                     private Country country;
                                 }
                                 """

--- a/src/test/java/com/ecpnv/openrewrite/jdo2jpa/ReplacePersistentWithManyToOneAnnotationIsolatedTest.java
+++ b/src/test/java/com/ecpnv/openrewrite/jdo2jpa/ReplacePersistentWithManyToOneAnnotationIsolatedTest.java
@@ -1,0 +1,207 @@
+/*
+ * Copyright 2024 the original author or authors.
+ * <p>
+ * Licensed under the Moderne Source Available License (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * <p>
+ * https://docs.moderne.io/licensing/moderne-source-available-license
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.ecpnv.openrewrite.jdo2jpa;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.DocumentExample;
+import org.openrewrite.test.RecipeSpec;
+
+import static org.openrewrite.java.Assertions.java;
+
+/**
+ * Isolated tests for {@link ReplacePersistentWithManyToOneAnnotation}.
+ * <p>
+ * Unlike {@link ReplacePersistentWithManyToOneAnnotationTest}, which runs the full
+ * {@code v2x.Persistent} composite (this recipe plus several clean-up recipes), this class runs
+ * <em>only</em> this recipe. That makes a failure attributable to this recipe and exercises the
+ * most complex paths (bi-directional {@code @OneToOne} detection) which the composite tests do not
+ * cover.
+ * <p>
+ * The cases below cover the behaviours that were previously untested and where bugs were found:
+ * <ul>
+ * <li>{@code dependent = "true"} on a single reference maps to a REMOVE cascade;
+ * <li>a reference field without {@code @Persistent} still gets an explicit {@code FetchType.LAZY}
+ * (JDO default), instead of silently becoming JPA's EAGER default;
+ * <li>the owning side of a bi-directional one-to-one becomes {@code @OneToOne}, and multiple
+ * inverse relationships to the <em>same</em> target type are all detected (no accumulator key
+ * collision).
+ * </ul>
+ * <p>
+ * Note: the inverse ({@code mappedBy}) side of a bi-directional relationship is intentionally
+ * <em>not</em> handled by this recipe; {@link ReplacePersistentWithOneToManyAnnotation} migrates it
+ * to {@code @OneToOne(mappedBy = ...)}. In these isolated runs the inverse fields therefore keep
+ * their {@code @Persistent} annotation.
+ *
+ * @see ReplacePersistentWithManyToOneAnnotation
+ */
+class ReplacePersistentWithManyToOneAnnotationIsolatedTest extends BaseRewriteTest {
+
+    private static final String DEFAULT_CASCADE =
+            "CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REFRESH, CascadeType.DETACH";
+
+    @Override
+    public void defaults(RecipeSpec spec) {
+        spec.parser(PARSER).recipe(new ReplacePersistentWithManyToOneAnnotation(DEFAULT_CASCADE));
+    }
+
+    /**
+     * A single reference marked {@code @Persistent(dependent = "true")} must translate to a
+     * {@code CascadeType.REMOVE} cascade. Previously only {@code dependentElement} (the collection
+     * attribute) was checked, so this cascade was silently dropped.
+     */
+    @Test
+    void dependentSingleReferenceGetsRemoveCascade() {
+        rewriteRun(
+                //language=java
+                java(
+                        """
+                                import javax.persistence.Entity;
+                                import javax.jdo.annotations.Persistent;
+
+                                @Entity
+                                public class Person {}
+                                @Entity
+                                public class SomeEntity {
+                                    @Persistent(dependent = "true")
+                                    private Person person;
+                                }
+                                """,
+                        """
+                                import javax.persistence.CascadeType;
+                                import javax.persistence.Entity;
+                                import javax.persistence.FetchType;
+                                import javax.persistence.ManyToOne;
+
+                                @Entity
+                                public class Person {}
+                                @Entity
+                                public class SomeEntity {
+                                    @ManyToOne(cascade = {CascadeType.REMOVE, CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REFRESH, CascadeType.DETACH}, fetch = FetchType.LAZY)
+                                    private Person person;
+                                }
+                                """
+                )
+        );
+    }
+
+    /**
+     * An entity reference without {@code @Persistent} in an entity class must still receive an
+     * explicit {@code FetchType.LAZY}. JDO loads single references lazily by default, whereas JPA
+     * defaults {@code @ManyToOne} to EAGER; without an explicit fetch the migration would silently
+     * change the loading behaviour.
+     */
+    @Test
+    void referenceWithoutPersistentGetsExplicitLazyFetch() {
+        rewriteRun(
+                //language=java
+                java(
+                        """
+                                import javax.persistence.Entity;
+
+                                @Entity
+                                public class Person {}
+                                @Entity
+                                public class SomeEntity {
+                                    private Person person;
+                                }
+                                """,
+                        """
+                                import javax.persistence.CascadeType;
+                                import javax.persistence.Entity;
+                                import javax.persistence.FetchType;
+                                import javax.persistence.ManyToOne;
+
+                                @Entity
+                                public class Person {}
+                                @Entity
+                                public class SomeEntity {
+                                    @ManyToOne(fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REFRESH, CascadeType.DETACH})
+                                    private Person person;
+                                }
+                                """
+                )
+        );
+    }
+
+    /**
+     * The owning side of a bi-directional one-to-one (the field that another entity's
+     * {@code mappedBy} points to) must become {@code @OneToOne} rather than {@code @ManyToOne}.
+     * Crucially, when two inverse relationships in different entities point at the <em>same</em>
+     * target type ({@code Address}), both owning-side fields must be detected. With the previous
+     * single-value accumulator the second mapping overwrote the first, so one owning-side field
+     * ({@code Address.person}) was wrongly left as {@code @ManyToOne}.
+     * <p>
+     * Running this recipe in isolation, the inverse fields ({@code Person.address},
+     * {@code Company.mainAddress}) keep their {@code @Persistent} annotation; the full composite
+     * migrates them via {@link ReplacePersistentWithOneToManyAnnotation}.
+     */
+    @DocumentExample
+    @Test
+    void multipleInverseRelationsToSameTargetTypeAreAllDetected() {
+        rewriteRun(
+                //language=java
+                java(
+                        """
+                                import javax.persistence.Entity;
+                                import javax.jdo.annotations.Persistent;
+
+                                @Entity
+                                public class Person {
+                                    @Persistent(mappedBy = "person")
+                                    private Address address;
+                                }
+                                @Entity
+                                public class Company {
+                                    @Persistent(mappedBy = "company")
+                                    private Address mainAddress;
+                                }
+                                @Entity
+                                public class Address {
+                                    @Persistent
+                                    private Person person;
+                                    @Persistent
+                                    private Company company;
+                                }
+                                """,
+                        """
+                                import javax.persistence.CascadeType;
+                                import javax.persistence.Entity;
+                                import javax.persistence.FetchType;
+                                import javax.persistence.OneToOne;
+                                import javax.jdo.annotations.Persistent;
+
+                                @Entity
+                                public class Person {
+                                    @Persistent(mappedBy = "person")
+                                    private Address address;
+                                }
+                                @Entity
+                                public class Company {
+                                    @Persistent(mappedBy = "company")
+                                    private Address mainAddress;
+                                }
+                                @Entity
+                                public class Address {
+                                    @OneToOne(fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REFRESH, CascadeType.DETACH})
+                                    private Person person;
+                                    @OneToOne(fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REFRESH, CascadeType.DETACH})
+                                    private Company company;
+                                }
+                                """
+                )
+        );
+    }
+}

--- a/src/test/java/com/ecpnv/openrewrite/jdo2jpa/ReplacePersistentWithOneToManyAnnotationTest.java
+++ b/src/test/java/com/ecpnv/openrewrite/jdo2jpa/ReplacePersistentWithOneToManyAnnotationTest.java
@@ -225,7 +225,7 @@ class ReplacePersistentWithOneToManyAnnotationTest extends BaseRewriteTest {
                                 
                                 @Entity
                                 public class Person {
-                                    @ManyToOne(cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REFRESH, CascadeType.DETACH})
+                                    @ManyToOne(fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REFRESH, CascadeType.DETACH})
                                     @JoinColumn(name = "someEntity_id")
                                     private SomeEntity someEntity;
                                 }
@@ -468,7 +468,7 @@ class ReplacePersistentWithOneToManyAnnotationTest extends BaseRewriteTest {
                                         @Index(name = "Person_entity_IDX", columnList = "someEntity_id, someEntity_name, someEntity_type"),
                                         @Index(name = "Person_name_IDX", columnList = "someEntity_name")})
                                 public class Person extends EntityAbstract {
-                                    @ManyToOne(cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REFRESH, CascadeType.DETACH})
+                                    @ManyToOne(fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REFRESH, CascadeType.DETACH})
                                     @JoinColumn(name = "someEntity_id")
                                     private SomeEntity someEntity;
                                     @Column(name = "someEntity_name")
@@ -563,7 +563,7 @@ class ReplacePersistentWithOneToManyAnnotationTest extends BaseRewriteTest {
                                         @Index(name = "Person_entity_IDX", columnList = "someEntity_id"),
                                         @Index(name = "Person_name_IDX", columnList = "someEntity_name")})
                                 public class Person extends EntityAbstract {
-                                    @OneToOne(cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REFRESH, CascadeType.DETACH})
+                                    @OneToOne(fetch = FetchType.LAZY, cascade = {CascadeType.PERSIST, CascadeType.MERGE, CascadeType.REFRESH, CascadeType.DETACH})
                                     @JoinColumn(name = "someEntity_id")
                                     private SomeEntity someEntity;
                                     @Column(name = "someEntity_name")


### PR DESCRIPTION
## Context

Fixes for the MAJOR findings from a code review of `ReplacePersistentWithManyToOneAnnotation`. All changes are covered by tests; the full suite is green (**167 tests, 0 failures**, 2 pre-existing skips) on Java 21.

## Changes

**1. `dependent` attribute ignored (migration risk)**
For single-valued references JDO uses `dependent`, not `dependentElement` (which applies to collection elements). The recipe only checked `dependentElement`, so `@Persistent(dependent = "true")` silently lost its `CascadeType.REMOVE`. Now checks `dependent` first, falling back to `dependentElement`.

**2. Silent lazy → eager fetch change (migration risk)**
A `fetch` type was only written when an `@Persistent` annotation was present. Bare entity references got no `fetch` attribute and therefore fell back to JPA's `EAGER` default, whereas JDO loads single references lazily. `fetch` is now always written explicitly (`LAZY` unless `defaultFetchGroup = "true"`). Existing composite/`JoinColumnTest` expectations were updated to the corrected output.

**3. Accumulator key collision (bug)**
`varPersistentWithMappedBy` mapped a target type to a *single* mappedBy field name, so two bi-directional relationships to the same target type overwrote each other and one owning-side field was wrongly left as `@ManyToOne`. Changed to `Map<String, Set<String>>` and extracted the owning-side check into `isOwningSideOfBidirectionalOneToOne`.

**4. Test coverage (test gap)**
Added `ReplacePersistentWithManyToOneAnnotationIsolatedTest`, which runs *only* this recipe (the existing tests run the full `v2x.Persistent` composite, which can mask this recipe's behaviour). Covers items 1-3 and the previously untested `@OneToOne` owning-side detection.

## A finding that was retracted after verification

The review also proposed that the inverse (`mappedBy`) side of a bi-directional 1:1 was never migrated. **This turned out to be wrong** and is *not* part of this PR: `ReplacePersistentWithOneToManyAnnotation` already migrates a non-collection `@Persistent(mappedBy = ...)` field to `@OneToOne(mappedBy = ...)` (see that class, lines ~219-228), as the existing `replacePersistentWithOneToOneAnnotationWithMultipleAnnotationsAndIndex` test proves. The initial conclusion came from reviewing this class in isolation rather than the full composite pipeline.

## Notes for the reviewer

- Item 2 changes output for **any** entity reference without an explicit fetch group; please sanity-check that `LAZY` is the intended default for the migrated codebase.
- These changes originated from an AI-assisted code-review knowledge session; feedback on both the fixes and the retracted finding is very welcome.
