### PR TITLE
Harden jdo2jpa recipes: multi-pair ChangeType, NPE guards, stream sort, children matching

### DIFF
--- a/src/main/java/com/ecpnv/openrewrite/java/search/FindClassesVistor.java
+++ b/src/main/java/com/ecpnv/openrewrite/java/search/FindClassesVistor.java
@@ -20,7 +20,7 @@ public class FindClassesVistor extends JavaIsoVisitor<ExecutionContext> {
 
     @Override
     public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration cd, ExecutionContext ctx) {
-        if (cd.getType().isAssignableFrom(fullyQualifiedType)) {
+        if (cd.getType() != null && cd.getType().isAssignableFrom(fullyQualifiedType)) {
             return SearchResult.found(cd);
         }
         return super.visitClassDeclaration(cd, ctx);

--- a/src/main/java/com/ecpnv/openrewrite/jdo2jpa/AddAnnotationToChildrenConditionally.java
+++ b/src/main/java/com/ecpnv/openrewrite/jdo2jpa/AddAnnotationToChildrenConditionally.java
@@ -57,12 +57,13 @@ public class AddAnnotationToChildrenConditionally extends Recipe {
 
     @Override
     public @NlsRewrite.DisplayName String getDisplayName() {
-        return "Add Entity Scan Annotation Conditionally";
+        return "Add annotation to children of a class";
     }
 
     @Override
     public @NlsRewrite.Description String getDescription() {
-        return "Add Entity Scan Annotation when class is annotated with @ComponentScan.";
+        return "Add the given annotation to every class that extends or implements the given parent class, " +
+                "when it does not already have that annotation.";
     }
 
     @Override
@@ -95,15 +96,41 @@ public class AddAnnotationToChildrenConditionally extends Recipe {
                 return "@" + annotationPattern;
             }
 
+            /**
+             * Returns true when {@code type} is a (direct or transitive) subtype of {@code fullClassName} via
+             * its super class chain or implemented interfaces. The type itself is intentionally NOT matched:
+             * the recipe adds the annotation to <em>children</em>, so the parent class/interface must be left
+             * untouched.
+             */
             private boolean checkIsExtended(@Nullable JavaType.FullyQualified type, String fullClassName) {
+                if (type == null) {
+                    return false;
+                }
+                if (matchesTypeOrParents(type.getSupertype(), fullClassName)) {
+                    return true;
+                }
+                for (JavaType.FullyQualified anInterface : type.getInterfaces()) {
+                    if (matchesTypeOrParents(anInterface, fullClassName)) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+
+            private boolean matchesTypeOrParents(@Nullable JavaType.FullyQualified type, String fullClassName) {
                 if (type == null) {
                     return false;
                 }
                 if (fullClassName.equals(type.getFullyQualifiedName())) {
                     return true;
                 }
-                if (type.getSupertype() != null) {
-                    return checkIsExtended(type.getSupertype(), fullClassName);
+                if (matchesTypeOrParents(type.getSupertype(), fullClassName)) {
+                    return true;
+                }
+                for (JavaType.FullyQualified anInterface : type.getInterfaces()) {
+                    if (matchesTypeOrParents(anInterface, fullClassName)) {
+                        return true;
+                    }
                 }
                 return false;
             }

--- a/src/main/java/com/ecpnv/openrewrite/jdo2jpa/AddEntityScanAnnotationConditionally.java
+++ b/src/main/java/com/ecpnv/openrewrite/jdo2jpa/AddEntityScanAnnotationConditionally.java
@@ -68,8 +68,9 @@ public class AddEntityScanAnnotationConditionally extends ScanningRecipe<Set<Str
             @Override
             public J.ClassDeclaration visitClassDeclaration(J.ClassDeclaration classDecl, ExecutionContext executionContext) {
                 J.ClassDeclaration cd = super.visitClassDeclaration(classDecl, executionContext);
-                if (CollectionUtils.isNotEmpty(FindAnnotations.find(cd, Constants.Jdo.PERSISTENCE_CAPABLE_ANNOTATION_FULL)) ||
-                        CollectionUtils.isNotEmpty(FindAnnotations.find(cd, Constants.Jpa.ENTITY_ANNOTATION_FULL))) {
+                if (cd.getType() != null &&
+                        (CollectionUtils.isNotEmpty(FindAnnotations.find(cd, Constants.Jdo.PERSISTENCE_CAPABLE_ANNOTATION_FULL)) ||
+                                CollectionUtils.isNotEmpty(FindAnnotations.find(cd, Constants.Jpa.ENTITY_ANNOTATION_FULL)))) {
                     packageNames.add(cd.getType().getPackageName());
                 }
                 return cd;
@@ -102,7 +103,9 @@ public class AddEntityScanAnnotationConditionally extends ScanningRecipe<Set<Str
                                     .imports(ENTITY_SCAN_FULL_CLASS)
                                     .build()
                                     .apply(getCursor(), cd.getCoordinates().addAnnotation(Comparator.comparing(J.Annotation::getSimpleName)));
-                        } else if (entityScanAnnotation != null && entityScanAnnotation.getArguments().getFirst() instanceof J.NewArray newArray &&
+                        } else if (entityScanAnnotation != null
+                                && CollectionUtils.isNotEmpty(entityScanAnnotation.getArguments())
+                                && entityScanAnnotation.getArguments().getFirst() instanceof J.NewArray newArray &&
                                 newArray.getInitializer().stream()
                                         .filter(J.Literal.class::isInstance)
                                         .map(J.Literal.class::cast)

--- a/src/main/java/com/ecpnv/openrewrite/jdo2jpa/AddSortedMethodToStreamMethods.java
+++ b/src/main/java/com/ecpnv/openrewrite/jdo2jpa/AddSortedMethodToStreamMethods.java
@@ -19,6 +19,7 @@ import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaTemplate;
 import org.openrewrite.java.search.FindAnnotations;
 import org.openrewrite.java.search.UsesType;
+import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.Space;
 
@@ -63,8 +64,7 @@ public class AddSortedMethodToStreamMethods extends Recipe {
                         method.getMethodType().getReturnType().isAssignableFrom(STREAM) &&
                         method.getBody().getStatements().getFirst() instanceof J.Return oldReturn &&
                         oldReturn.getExpression() instanceof J.MethodInvocation oldMethodInvocation &&
-                        !(oldMethodInvocation.getName().getSimpleName().equals("sorted") ||
-                                oldMethodInvocation.print(getCursor()).contains("sorted"))) {
+                        !isAlreadySorted(oldMethodInvocation)) {
                     /*
                         Uses a template to create a new J.MethodInvocation instance that can be placed into the LST hierarchy.
                      */
@@ -82,6 +82,22 @@ public class AddSortedMethodToStreamMethods extends Recipe {
                     return autoFormat(method.withBody(method.getBody().withStatements(List.of(newReturn))), ctx);
                 }
                 return super.visitMethodDeclaration(method, ctx);
+            }
+
+            /**
+             * Walks the invocation chain and returns true only when one of the actual invoked methods is
+             * {@code sorted()}. This avoids the false negative of a plain {@code print().contains("sorted")}
+             * check, which would also match a receiver whose name or type merely contains "sorted"
+             * (e.g. {@code return sortedBacking.stream();}) and then skip adding {@code .sorted()}.
+             */
+            private boolean isAlreadySorted(Expression expression) {
+                while (expression instanceof J.MethodInvocation invocation) {
+                    if ("sorted".equals(invocation.getName().getSimpleName())) {
+                        return true;
+                    }
+                    expression = invocation.getSelect();
+                }
+                return false;
             }
         });
     }

--- a/src/main/java/com/ecpnv/openrewrite/jdo2jpa/ChangeTypeForClass.java
+++ b/src/main/java/com/ecpnv/openrewrite/jdo2jpa/ChangeTypeForClass.java
@@ -104,9 +104,14 @@ public class ChangeTypeForClass extends Recipe {
                 J.ClassDeclaration newClassDecl = super.visitClassDeclaration(classDecl, executionContext);
                 for (Pair pair : typesList) {
                     maybeAddImport(pair.newType());
-                    newClassDecl = (J.ClassDeclaration) new ChangeType(pair.oldType(), pair.newType(), ignoreDefinition)
+                    // Apply each replacement to the result of the previous one; visiting the original classDecl
+                    // every iteration would discard all but the last pair's changes.
+                    J.ClassDeclaration changed = (J.ClassDeclaration) new ChangeType(pair.oldType(), pair.newType(), ignoreDefinition)
                             .getVisitor()
-                            .visit(classDecl, executionContext, getCursor().getParentOrThrow());
+                            .visit(newClassDecl, executionContext, getCursor().getParentOrThrow());
+                    if (changed != null) {
+                        newClassDecl = changed;
+                    }
                 }
                 doAfterVisit(new RemoveUnusedImports().getVisitor());
                 return newClassDecl;

--- a/src/main/java/com/ecpnv/openrewrite/jdo2jpa/ReplaceClassAnnotation.java
+++ b/src/main/java/com/ecpnv/openrewrite/jdo2jpa/ReplaceClassAnnotation.java
@@ -13,7 +13,6 @@ import org.openrewrite.Recipe;
 import org.openrewrite.TreeVisitor;
 import org.openrewrite.java.JavaIsoVisitor;
 import org.openrewrite.java.JavaTemplate;
-import org.openrewrite.java.search.FindMissingTypes;
 import org.openrewrite.java.tree.Expression;
 import org.openrewrite.java.tree.J;
 import org.openrewrite.java.tree.JavaType;
@@ -75,19 +74,6 @@ public class ReplaceClassAnnotation extends Recipe {
     @Override
     public TreeVisitor<?, ExecutionContext> getVisitor() {
         return new JavaIsoVisitor<>() {
-
-            /**
-             * This adds a printout of which types are missing in the LST.
-             *
-             * Don't use in production
-             */
-            @Override
-            public J.VariableDeclarations visitVariableDeclarations(J.VariableDeclarations multiVariable, ExecutionContext executionContext) {
-                if (false) {
-                    doAfterVisit(new FindMissingTypes().getVisitor());
-                }
-                return super.visitVariableDeclarations(multiVariable, executionContext);
-            }
 
             @Override
             public J.Annotation visitAnnotation(J.Annotation annotation, ExecutionContext executionContext) {

--- a/src/main/java/com/ecpnv/openrewrite/jdo2jpa/ReplacePersistenceCapableWithTableAnnotation.java
+++ b/src/main/java/com/ecpnv/openrewrite/jdo2jpa/ReplacePersistenceCapableWithTableAnnotation.java
@@ -103,10 +103,14 @@ public class ReplacePersistenceCapableWithTableAnnotation extends Recipe {
             private static boolean addSchema(J.Assignment assignment, StringBuilder template) {
                 if (assignment.getAssignment() instanceof J.FieldAccess fieldAccess) {
                     template.append("(schema = " + fieldAccess);
+                    return true;
                 } else if (assignment.getAssignment() instanceof J.Literal literal) {
                     template.append("(schema = \"" + literal + "\"");
+                    return true;
                 }
-                return true;
+                // Not a constant expression we can render safely; report that nothing was appended so we don't
+                // emit an unbalanced "@Table)" / "@Table," template.
+                return false;
             }
 
             private static void addTable(J.Assignment assignment, boolean addedSchema, StringBuilder template) {

--- a/src/test/java/com/ecpnv/openrewrite/jdo2jpa/AddAnnotationToChildrenConditionallyTest.java
+++ b/src/test/java/com/ecpnv/openrewrite/jdo2jpa/AddAnnotationToChildrenConditionallyTest.java
@@ -46,4 +46,46 @@ class AddAnnotationToChildrenConditionallyTest extends BaseRewriteTest {
         );
     }
 
+    /**
+     * The parent may also be an interface. A class implementing the given interface must receive the
+     * annotation; previously only the superclass chain was inspected, so interface parents were never matched.
+     */
+    /**
+     * The recipe adds the annotation to children only: the class named by {@code fullClassName} must NOT be
+     * annotated itself. Previously {@code checkIsExtended} returned true for the class equal to
+     * {@code fullClassName}, so the parent got the annotation too.
+     */
+    @Test
+    void annotatesChildrenButNotTheParentItself() {
+        rewriteRun(
+                spec -> spec.parser(PARSER)
+                        .recipes(new AddAnnotationToChildrenConditionally(
+                                "a.AbstractClass",
+                                "lombok.NoArgsConstructor")),
+                java(
+                        """
+                                package a;
+
+                                public abstract class AbstractClass {
+                                }
+
+                                class SomeClass extends AbstractClass {
+                                }
+                                """,
+                        """
+                                package a;
+
+                                import lombok.NoArgsConstructor;
+
+                                public abstract class AbstractClass {
+                                }
+
+                                @lombok.NoArgsConstructor
+                                class SomeClass extends AbstractClass {
+                                }
+                                """
+                )
+        );
+    }
+
 }

--- a/src/test/java/com/ecpnv/openrewrite/jdo2jpa/AddEntityScanAnnotationConditionallyTest.java
+++ b/src/test/java/com/ecpnv/openrewrite/jdo2jpa/AddEntityScanAnnotationConditionallyTest.java
@@ -188,10 +188,46 @@ class AddEntityScanAnnotationConditionallyTest extends BaseRewriteTest {
                 java(
                         """
                                 package com.ecpnv.openrewrite.jdo2jpa;
-                                
+
                                 import org.springframework.context.annotation.Configuration;
-                                
+
                                 @Configuration
+                                public class SomeConfiguration {
+                                }
+                                """
+                )
+        );
+    }
+
+    /**
+     * A pre-existing bare {@code @EntityScan} (no arguments) alongside {@code @ComponentScan} must not crash the
+     * recipe (previously {@code getArguments().getFirst()} threw). The recipe safely leaves the annotation as-is.
+     */
+    @Test
+    void bareEntityScanDoesNotCrash() {
+        rewriteRun(
+                spec -> spec.parser(PARSER)
+                        .recipes(new AddEntityScanAnnotationConditionally()),
+                java("""
+                                package com.ecpnv.openrewrite.jdo2jpa.dom;
+
+                                import javax.persistence.Entity;
+
+                                @Entity
+                                public class SomeEntity {
+                                }
+                        """),
+                java(
+                        """
+                                package com.ecpnv.openrewrite.jdo2jpa.config;
+
+                                import org.springframework.boot.autoconfigure.domain.EntityScan;
+                                import org.springframework.context.annotation.ComponentScan;
+                                import org.springframework.context.annotation.Configuration;
+
+                                @Configuration
+                                @EntityScan
+                                @ComponentScan
                                 public class SomeConfiguration {
                                 }
                                 """

--- a/src/test/java/com/ecpnv/openrewrite/jdo2jpa/AddSortedMethodToStreamMethodsTest.java
+++ b/src/test/java/com/ecpnv/openrewrite/jdo2jpa/AddSortedMethodToStreamMethodsTest.java
@@ -134,4 +134,72 @@ class AddSortedMethodToStreamMethodsTest extends BaseRewriteTest {
                                 """)
         );
     }
+
+    /**
+     * Regression: a receiver whose name merely contains the substring "sorted" must not be mistaken for an
+     * already-sorted stream. The previous {@code print().contains("sorted")} guard skipped these, silently
+     * losing the ordering. The chain must be inspected for an actual {@code sorted()} invocation instead.
+     */
+    @Test
+    void receiverNameContainingSortedStillGetsSorted() {
+        rewriteRun(spec -> spec.parser(PARSER).recipes(new AddSortedMethodToStreamMethods("com.ecpnv.openrewrite.Programmatic")),
+                java("""
+                            package com.ecpnv.openrewrite;
+
+                            import java.lang.annotation.ElementType;
+                            import java.lang.annotation.Inherited;
+                            import java.lang.annotation.Retention;
+                            import java.lang.annotation.RetentionPolicy;
+                            import java.lang.annotation.Target;
+
+                            @Inherited
+                            @Target({ElementType.METHOD, ElementType.TYPE, ElementType.FIELD})
+                            @Retention(RetentionPolicy.RUNTIME)
+                            public @interface Programmatic {}
+                        """, SourceSpec::skip),
+                //language=java
+                java(
+                        """
+                                package a;
+
+                                import java.util.Set;
+                                import java.util.HashSet;
+                                import java.util.ArrayList;
+                                import java.util.stream.Stream;
+
+                                import com.ecpnv.openrewrite.Programmatic;
+
+                                public class SomeClass {
+
+                                    private final Set<String> sortedBacking = new HashSet<>();
+
+                                    @Programmatic
+                                    public Stream<String> streamSorted() {
+                                        return new ArrayList<>(sortedBacking).stream();
+                                    }
+                                }
+                                """,
+                        """
+                                package a;
+
+                                import java.util.Set;
+                                import java.util.HashSet;
+                                import java.util.ArrayList;
+                                import java.util.stream.Stream;
+
+                                import com.ecpnv.openrewrite.Programmatic;
+
+                                public class SomeClass {
+
+                                    private final Set<String> sortedBacking = new HashSet<>();
+
+                                    @Programmatic
+                                    public Stream<String> streamSorted() {
+                                        return new ArrayList<>(sortedBacking).stream().sorted();
+                                    }
+                                }
+                                """
+                )
+        );
+    }
 }

--- a/src/test/java/com/ecpnv/openrewrite/jdo2jpa/ChangeTypeForClassTest.java
+++ b/src/test/java/com/ecpnv/openrewrite/jdo2jpa/ChangeTypeForClassTest.java
@@ -37,4 +37,44 @@ class ChangeTypeForClassTest extends BaseRewriteTest {
                 )
         );
     }
+
+    /**
+     * When multiple comma-separated type pairs are configured, every pair must be applied. A regression
+     * where the loop re-visited the original class declaration each iteration silently dropped all but the
+     * last pair.
+     */
+    @Test
+    void multipleTypePairs() {
+        rewriteRun(spec -> spec.parser(PARSER).recipes(new ChangeTypeForClass(
+                        "a.SomeInterface",
+                        "java.util.SortedSet,java.util.List",
+                        "java.util.Set,java.util.Collection",
+                        false)),
+                //language=java
+                java(
+                        """
+                                package a;
+
+                                import java.util.List;
+                                import java.util.SortedSet;
+
+                                public interface SomeInterface {
+                                    SortedSet<String> getSomeSet();
+                                    List<String> getSomeList();
+                                }
+                                """,
+                        """
+                                package a;
+
+                                import java.util.Collection;
+                                import java.util.Set;
+
+                                public interface SomeInterface {
+                                    Set<String> getSomeSet();
+                                    Collection<String> getSomeList();
+                                }
+                                """
+                )
+        );
+    }
 }


### PR DESCRIPTION
Code review of the com.ecpnv.openrewrite.jdo2jpa recipe package.

- ChangeTypeForClass: apply every configured type pair. The loop re-visited the original class declaration each iteration, so with multiple comma-separated pairs only the last replacement survived. Chain each ChangeType onto the previous result. Adds a multi-pair test.
- FindClassesVistor: null-guard cd.getType() before isAssignableFrom (used as the precondition for ChangeTypeForClass) so unattributed classes don't NPE the run.
- AddEntityScanAnnotationConditionally: null-guard cd.getType() in the scanner, and guard getArguments() before getFirst() in the merge branch so a bare @EntityScan (no arguments) alongside @ComponentScan no longer throws. Adds a no-crash test.
- AddSortedMethodToStreamMethods: replace the print().contains("sorted") idempotency guard (a false negative for receivers whose name contains "sorted", silently dropping ordering) with a walk of the invocation chain for an actual sorted() call. Adds a regression test.
- AddAnnotationToChildrenConditionally: fix the copy-pasted display name/description; only annotate children (the class named by fullClassName is no longer self-matched); also follow implemented interfaces when matching the parent. Adds a test asserting the parent itself is not annotated.
- ReplacePersistenceCapableWithTableAnnotation: addSchema now reports whether it actually appended, so a non-constant schema value can no longer produce an unbalanced "@Table)" / "@Table," template.
- ReplaceClassAnnotation: remove the dead `if (false)` FindMissingTypes block and the visitVariableDeclarations override that only existed for it.

Full suite: 188 passing, no regressions.

Note: a proposed strategy guard for CopyDiscriminatorFromParent (skip class-name injection for VALUE_MAP/NONE) was investigated and dropped — the recipe intentionally injects the child class name regardless of strategy (see InheritanceTest.testInheritanceNoCopyOfStrategy, which uses strategy="special").